### PR TITLE
Add build hook to pass build arguments

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,1 @@
+docker build --build-arg GITLAB_USER=$GITLAB_USER --build-arg GITLAB_PASS=$GITLAB_PASS -t $IMAGE_NAME .


### PR DESCRIPTION
Docker Cloud require to add a build hook to recover environment variables and pass to build command as build-args